### PR TITLE
Add AI workflow tests

### DIFF
--- a/TicketSolver.IA.Tests/TicketSolver.IA.Tests.csproj
+++ b/TicketSolver.IA.Tests/TicketSolver.IA.Tests.csproj
@@ -29,6 +29,10 @@
         <ProjectReference Include="..\TicketSolver.Api\TicketSolver.Api.csproj" />
         <ProjectReference Include="..\TicketSolver.Application\TicketSolver.Application.csproj" />
         <ProjectReference Include="..\TicketSolver.Domain\TicketSolver.Domain.csproj" />
+        <ProjectReference Include="..\TicketSolver.Api.Application\TicketSolver.Api.Application.csproj" />
+        <ProjectReference Include="..\TicketSolver.Api.Infra\TicketSolver.Api.Infra.csproj" />
+        <ProjectReference Include="..\TicketSolver.Framework.Application\TicketSolver.Framework.Application.csproj" />
+        <ProjectReference Include="..\TicketSolver.Framework.Domain\TicketSolver.Framework.Domain.csproj" />
     </ItemGroup>
 
 </Project>

--- a/TicketSolver.IA.Tests/Workflow/AiContextProviderTests.cs
+++ b/TicketSolver.IA.Tests/Workflow/AiContextProviderTests.cs
@@ -1,0 +1,66 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using TicketSolver.Api.Application;
+using TicketSolver.Api.Application.Interfaces;
+using TicketSolver.Framework.Domain;
+using Xunit;
+
+namespace TicketSolver.IA.Tests.Workflow;
+
+public class AiContextProviderTests
+{
+    [Fact]
+    public async Task GetAiContext_ContextExists_ReturnsFromRepository()
+    {
+        // Arrange
+        var tenant = new Tenant("web");
+        var existing = new AiContext("prompt");
+
+        var repo = new Mock<IAiContextRepository>();
+        repo.Setup(r => r.GetContext(It.IsAny<CancellationToken>(), tenant))
+            .ReturnsAsync(existing);
+
+        var external = new Mock<IExternalInfoService>();
+
+        var provider = new AiContextProvider(repo.Object, external.Object);
+
+        // Act
+        var result = await provider.GetAiContext(tenant, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(existing, result);
+        external.Verify(e => e.GetContext(It.IsAny<CancellationToken>(), It.IsAny<Tenant>()), Times.Never);
+        repo.Verify(r => r.AddAiContext(It.IsAny<CancellationToken>(), It.IsAny<AiContext>(), It.IsAny<Tenant>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetAiContext_ContextMissing_FetchesAndStores()
+    {
+        // Arrange
+        var tenant = new Tenant("mobile");
+        var externalCtx = new AiContext("external");
+
+        var repo = new Mock<IAiContextRepository>();
+        repo.Setup(r => r.GetContext(It.IsAny<CancellationToken>(), tenant))
+            .ReturnsAsync((AiContext?)null);
+        repo.Setup(r => r.AddAiContext(It.IsAny<CancellationToken>(), externalCtx, tenant))
+            .Returns(Task.CompletedTask)
+            .Verifiable();
+
+        var external = new Mock<IExternalInfoService>();
+        external.Setup(e => e.GetContext(It.IsAny<CancellationToken>(), tenant))
+            .ReturnsAsync(externalCtx)
+            .Verifiable();
+
+        var provider = new AiContextProvider(repo.Object, external.Object);
+
+        // Act
+        var result = await provider.GetAiContext(tenant, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(externalCtx, result);
+        external.Verify();
+        repo.Verify();
+    }
+}

--- a/TicketSolver.IA.Tests/Workflow/BaseChatServiceTests.cs
+++ b/TicketSolver.IA.Tests/Workflow/BaseChatServiceTests.cs
@@ -1,0 +1,52 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using TicketSolver.Application.Models;
+using TicketSolver.Application.Ports;
+using TicketSolver.Framework.Application;
+using TicketSolver.Framework.Domain;
+using Xunit;
+
+namespace TicketSolver.IA.Tests.Workflow;
+
+public class BaseChatServiceTests
+{
+    [Fact]
+    public async Task CreateTicketAsync_UsesContextAndReturnsAiResponse()
+    {
+        // Arrange
+        var tenant = new Tenant("1");
+        var aiContext = new AiContext("system-prompt");
+
+        var contextProvider = new Mock<IAiContextProvider>();
+        contextProvider.Setup(p => p.GetAiContext(tenant, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(aiContext);
+
+        var aiProvider = new Mock<IAiProvider>();
+        string? capturedPrompt = null;
+        aiProvider.Setup(p => p.GenerateTextAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<string, CancellationToken>((prompt, _) => capturedPrompt = prompt)
+            .ReturnsAsync("ai-response");
+
+        var service = new BaseChatService(contextProvider.Object, aiProvider.Object);
+        var ticketDto = new TicketDTO
+        {
+            Title = "Issue title",
+            Description = "Issue desc",
+            Category = short.Parse(tenant.Id)
+        };
+
+        // Act
+        var result = await service.CreateTicketAsync(CancellationToken.None, ticketDto);
+
+        // Assert
+        Assert.Equal("ai-response", result);
+        Assert.NotNull(capturedPrompt);
+        Assert.Contains(aiContext.SystemPrompt, capturedPrompt);
+        Assert.Contains(ticketDto.Title, capturedPrompt!);
+        Assert.Contains(ticketDto.Description, capturedPrompt!);
+
+        contextProvider.Verify(p => p.GetAiContext(tenant, It.IsAny<CancellationToken>()), Times.Once);
+        aiProvider.Verify(p => p.GenerateTextAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/TicketSolver.IA.Tests/Workflow/FrameworkChatControllerTests.cs
+++ b/TicketSolver.IA.Tests/Workflow/FrameworkChatControllerTests.cs
@@ -1,0 +1,52 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using TicketSolver.Api.Framework;
+using TicketSolver.Application.Models;
+using TicketSolver.Framework.Application;
+using TicketSolver.Framework.Domain;
+using Xunit;
+
+namespace TicketSolver.IA.Tests.Workflow;
+
+public class FrameworkChatControllerTests
+{
+    [Fact]
+    public async Task StartChatAsync_ReturnsOkWithServiceResult()
+    {
+        var chatService = new Mock<IChatService>();
+        chatService.Setup(s => s.CreateTicketAsync(It.IsAny<CancellationToken>(), It.IsAny<TicketDTO>()))
+            .ReturnsAsync("ok");
+        var repo = new Mock<IAiContextRepository>();
+
+        var controller = new ChatController(chatService.Object, repo.Object);
+
+        var ticket = new TicketDTO { Title = "t", Description = "d", Category = 1 };
+        var result = await controller.StartChatAsync(ticket, CancellationToken.None);
+
+        var ok = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.Equal("ok", ok.Value);
+        chatService.Verify(s => s.CreateTicketAsync(It.IsAny<CancellationToken>(), ticket), Times.Once);
+    }
+
+    [Fact]
+    public async Task AddAiContextAsync_PersistsContext()
+    {
+        var chatService = new Mock<IChatService>();
+        var repo = new Mock<IAiContextRepository>();
+        repo.Setup(r => r.AddAiContext(It.IsAny<CancellationToken>(), It.IsAny<AiContext>(), It.IsAny<Tenant>()))
+            .Returns(Task.CompletedTask)
+            .Verifiable();
+
+        var controller = new ChatController(chatService.Object, repo.Object);
+
+        var result = await controller.AddAiContextAsync("web", "prompt", CancellationToken.None);
+
+        Assert.IsType<OkResult>(result);
+        repo.Verify(r => r.AddAiContext(
+            It.IsAny<CancellationToken>(),
+            It.Is<AiContext>(c => c.SystemPrompt == "prompt"),
+            It.Is<Tenant>(t => t.Id == "web")), Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests verifying AiContextProvider behavior
- add unit tests for BaseChatService
- add unit tests covering ChatController endpoints
- reference needed projects in test csproj

## Testing
- `dotnet test TicketSolver.IA.Tests/TicketSolver.IA.Tests.csproj --verbosity minimal` *(fails: NETSDK1045)*

------
https://chatgpt.com/codex/tasks/task_e_68764199d7e48329a3fa4e82445022db