### PR TITLE
Fix AI provider and add tests

### DIFF
--- a/TicketSolver.Api.Infra/ExternalInfoService.cs
+++ b/TicketSolver.Api.Infra/ExternalInfoService.cs
@@ -1,26 +1,20 @@
 using TicketSolver.Framework.Domain;
 using TicketSolver.Api.Application.Interfaces;
 using TicketSolver.Api.Infra.SystemPrompts;
-using TicketSolver.Domain.Persistence.Tables.Tenant;
 
 namespace TicketSolver.Api.Infra;
 
 public class ExternalInfoService : IExternalInfoService
 {
-    public Task<AiContext> GetContext(CancellationToken cancellationToken, Tenants tenant)
+    public Task<AiContext> GetContext(CancellationToken cancellationToken, Tenant tenant)
     {
-        var prompt = tenant.ApplicationType switch
+        var prompt = tenant.Id.ToLowerInvariant() switch
         {
-            ApplicationType.Mobile     => MobileSystemPrompt.Text,
-            ApplicationType.Web        => WebSystemPrompt.Text,
-            _                           => EnterpriseSystemPrompt.Text
+            "mobile" => MobileSystemPrompt.Text,
+            "web"    => WebSystemPrompt.Text,
+            _         => EnterpriseSystemPrompt.Text
         };
 
         return Task.FromResult(new AiContext(prompt));
-    }
-
-    public Task<AiContext> GetContext(CancellationToken cancellationToken, Tenant tenant)
-    {
-        throw new NotImplementedException();
     }
 }

--- a/TicketSolver.IA.Tests/Workflow/AiContextProviderTests.cs
+++ b/TicketSolver.IA.Tests/Workflow/AiContextProviderTests.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Moq;
 using TicketSolver.Api.Application;
 using TicketSolver.Api.Application.Interfaces;
-using TicketSolver.Domain.Persistence.Tables.Tenant;
 using TicketSolver.Framework.Domain;
 using Xunit;
 
@@ -15,7 +14,7 @@ public class AiContextProviderTests
     public async Task GetAiContext_ContextExists_ReturnsFromRepository()
     {
         // Arrange
-        var tenant = new Tenants("web");
+        var tenant = new Tenant("web");
         var existing = new AiContext("prompt");
 
         var repo = new Mock<IAiContextRepository>();
@@ -39,8 +38,8 @@ public class AiContextProviderTests
     public async Task GetAiContext_ContextMissing_FetchesAndStores()
     {
         // Arrange
-        var tenant = new Tenants("mobile");
-        var externalCtx = new AiContextProvider("external");
+        var tenant = new Tenant("mobile");
+        var externalCtx = new AiContext("external");
 
         var repo = new Mock<IAiContextRepository>();
         repo.Setup(r => r.GetContext(It.IsAny<CancellationToken>(), tenant))

--- a/TicketSolver.IA.Tests/Workflow/ExternalInfoServiceTests.cs
+++ b/TicketSolver.IA.Tests/Workflow/ExternalInfoServiceTests.cs
@@ -1,0 +1,25 @@
+using System.Threading;
+using System.Threading.Tasks;
+using TicketSolver.Api.Infra;
+using TicketSolver.Framework.Domain;
+using TicketSolver.Api.Infra.SystemPrompts;
+using Xunit;
+
+namespace TicketSolver.IA.Tests.Workflow;
+
+public class ExternalInfoServiceTests
+{
+    [Theory]
+    [InlineData("mobile", MobileSystemPrompt.Text)]
+    [InlineData("web", WebSystemPrompt.Text)]
+    [InlineData("enterprise", EnterpriseSystemPrompt.Text)]
+    public async Task GetContext_ReturnsPromptBasedOnTenant(string tenantId, string expected)
+    {
+        var service = new ExternalInfoService();
+        var tenant = new Tenant(tenantId);
+
+        var ctx = await service.GetContext(CancellationToken.None, tenant);
+
+        Assert.Equal(expected, ctx.SystemPrompt);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `ExternalInfoService.GetContext` properly
- fix `AiContextProviderTests`
- add tests for `ExternalInfoService` behaviour

## Testing
- `dotnet test` *(fails: NETSDK1045 - .NET 9.0 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687a83e8cc18832995c38da946ee0748